### PR TITLE
release the job if it is being held at OSG

### DIFF
--- a/Cluster_supports/OSG/generate_submission_script.py
+++ b/Cluster_supports/OSG/generate_submission_script.py
@@ -67,6 +67,9 @@ max_idle = 1000
 # remove the failed jobs
 periodic_remove = (ExitCode == 73)
 
+# release the job if it is being held
+periodic_release = (JobStatus == 5)
+
 checkpoint_exit_code = 85
 
 # Send the job to Held state on failure.


### PR DESCRIPTION
Problem: Jobs can be held when running on OSG. If the number of held jobs reaches a certain value, no new job will start running.

Solution: Use periodic_release to automatically release the held job. JobStatus is 5 for held jobs.

Reference: https://batchdocs.web.cern.ch/tutorial/exercise7.html

Test shows that the solution works. 