### PR TITLE
Fix KoMPoST

### DIFF
--- a/codes/get_code_packages.sh
+++ b/codes/get_code_packages.sh
@@ -17,7 +17,7 @@ rm -fr ipglasma_code/.git
 # download KoMPoST
 rm -fr kompost_code
 git clone --depth=1 https://github.com/chunshen1987/KoMPoST kompost_code
-(cd kompost_code; git checkout 3a8f873bcf8e20ec8522cb851d20ae5e66610085)
+(cd kompost_code; git checkout ad5fe9d3b26434bb1d5c29820499ef26808b5a47)
 rm -fr kompost_code/.git
 
 # download MUSIC

--- a/codes/hydro_plus_UrQMD_driver.py
+++ b/codes/hydro_plus_UrQMD_driver.py
@@ -480,7 +480,7 @@ def zip_results_into_hdf5(final_results_folder, event_id, para_dict):
                         "ecc_ed_*.dat",]
 
     pre_equilibrium_filelist = [
-        'ekt_tIn01_tOut08.music_init_flowNonLinear_pimunuTransverse.txt'
+        f'{para_dict['kompost_filename']}.music_init_flowNonLinear_pimunuTransverse.txt'
     ]
     hydro_info_filepattern = [
         "eccentricities_evo_*.dat", "momentum_anisotropy_*.dat",
@@ -737,7 +737,7 @@ def main(para_dict_):
             call("ln -s {0:s} {1:s}".format(
                 path.join(path.abspath(final_results_folder),
                           kompost_folder_name,
-                          ("ekt_tIn01_tOut08"
+                          (para_dict_['kompost_filename']
                            + ".music_init_flowNonLinear_pimunuTransverse.txt")),
                 hydro_initial_file),
                  shell=True)
@@ -844,6 +844,11 @@ if __name__ == "__main__":
         print_usage()
         sys.exit(0)
 
+    try:
+        KOMPOST_FILENAME = str(sys.argv[17])
+    except IndexError:
+        KOMPOST_FILENAME = "ekt_tIn01_tOut08"
+
     known_initial_types = [
         "IPGlasma", "IPGlasma+KoMPoST",
         "3DMCGlauber_dynamical", "3DMCGlauber_participants",
@@ -873,6 +878,7 @@ if __name__ == "__main__":
         'time_stamp_str': TIME_STAMP,
         'check_point_flag': CHECK_POINT,
         'afterburner_type': AFTERBURNER_TYPE,
+        'kompost_filename': KOMPOST_FILENAME,
     }
 
     main(para_dict)

--- a/generate_jobs.py
+++ b/generate_jobs.py
@@ -241,7 +241,7 @@ def generate_full_job_script(cluster_name, folder_name, database, initial_type,
                         working_folder)
     script.write("\nseed_add=${1:-0}\n")
     script.write("""
-python3 hydro_plus_UrQMD_driver.py {0:s} {1:s} {2:d} {3:d} {4:d} {5:d} {6} {7} {8} {9} $seed_add {10:s} {11} {12} {13} {14:s}
+python3 hydro_plus_UrQMD_driver.py {0:s} {1:s} {2:d} {3:d} {4:d} {5:d} {6} {7} {8} {9} $seed_add {10:s} {11} {12} {13} {14:s} {15:s}
 """.format(initial_type, database, n_hydro, ev0_id, n_urqmd, n_threads,
            para_dict.control_dict["save_ipglasma_results"],
            para_dict.control_dict["save_kompost_results"],
@@ -250,7 +250,8 @@ python3 hydro_plus_UrQMD_driver.py {0:s} {1:s} {2:d} {3:d} {4:d} {5:d} {6} {7} {
            time_stamp,
            para_dict.control_dict["compute_polarization"],
            para_dict.control_dict["compute_photon_emission"],
-           enableCheckPoint, afterburner_type))
+           enableCheckPoint,afterburner_type,
+           para_dict.kompost_dict["KoMPoSTInputs"]["OutputFileTag"]))
     script.write("""
 
 status=$?


### PR DESCRIPTION
This fixes the propagation of the KoMPoST filename from the parameter file to the output and also the `normFactor` in the KoMPoST part, which is implemented in the fork: https://github.com/KMPST/KoMPoST/commit/ad5fe9d3b26434bb1d5c29820499ef26808b5a47